### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/src/batch-manager.js
+++ b/src/batch-manager.js
@@ -10,6 +10,16 @@ import {
   onSnapshot,
 } from "firebase/firestore";
 
+// Utility function for escaping HTML special characters
+function escapeHTML(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 // ====================== STATE ======================
 
 let batches = {};
@@ -914,7 +924,7 @@ document.addEventListener("DOMContentLoaded", function () {
       item.addEventListener("click", async () => {
         if (btn) {
           btn.innerHTML =
-            "⏰ " + item.textContent + ' <span class="arrow">⌄</span>';
+            "⏰ " + escapeHTML(item.textContent) + ' <span class="arrow">⌄</span>';
         }
         if (selectedBatch) {
           batches[selectedBatch].Time = item.textContent;
@@ -937,7 +947,7 @@ document.addEventListener("DOMContentLoaded", function () {
   if (btn) {
     const current = selectedBatch && batches[selectedBatch]?.Time;
     const defaultTime = current || "11:00 AM - 12:00 PM";
-    btn.innerHTML = `⏰ ${defaultTime} <span class="arrow">⌄</span>`;
+    btn.innerHTML = `⏰ ${escapeHTML(defaultTime)} <span class="arrow">⌄</span>`;
     const hiddenInput = document.getElementById("time");
     if (hiddenInput && !hiddenInput.value) hiddenInput.value = defaultTime;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/SidharthT-TechExpert/attendance-trackers/security/code-scanning/8](https://github.com/SidharthT-TechExpert/attendance-trackers/security/code-scanning/8)

The problem lies in using untrusted DOM text (from `item.textContent` or `batches[selectedBatch].Time`) directly inside a template literal assigned to `innerHTML`, which can allow HTML injection.  
To fix this, we should **encode the text for HTML context** before inserting it into `.innerHTML`. The best way is to escape HTML special characters in `defaultTime` before including it in the string.  
- In both places where `.innerHTML` is set (`btn.innerHTML = ...` on line 916 and line 940), we should wrap the interpolated text (`item.textContent` or `defaultTime`) with a function that escapes HTML meta-characters.
- Define a small utility function `escapeHTML` in this file (or import one from a well-known library if allowed), and use it for escaping in both these locations.
- Only edit shown regions in `src/batch-manager.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
